### PR TITLE
Use a single thread for durable queue enqueue operations

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-(defproject arion "1.2.2"
+(defproject arion "1.2.3-SNAPSHOT"
   :description "Talks to Kafka so you don't have to"
   :url "https://github.com/orgsync/arion"
   :license {:name "Apache 2.0"
@@ -22,18 +22,18 @@
                  [byte-streams "0.2.2"]
                  [camel-snake-kebab "0.4.0"]
                  [com.stuartsierra/component "0.3.1"]
-                 [com.taoensso/timbre "4.3.1"]
+                 [com.taoensso/timbre "4.7.4"]
                  [danlentz/clj-uuid "0.1.6"]
-                 [environ "1.0.3"]
+                 [environ "1.1.0"]
                  [factual/durable-queue "0.1.5"]
                  [gloss "0.2.6"]
-                 [manifold "0.1.4"]
+                 [manifold "0.1.5"]
                  [metrics-clojure "2.7.0"]
                  [metrics-clojure-jvm "2.7.0"]
                  [metrics-statsd "0.1.5"]
                  [org.apache.kafka/kafka-clients "0.9.0.1"]
                  [org.clojure/clojure "1.8.0"]
-                 [pjson "0.3.2"]]
+                 [pjson "0.3.4"]]
   :main arion.core
   :uberjar-name "arion.jar"
   :repl-options {:host "0.0.0.0"}

--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
                  [manifold "0.1.5"]
                  [metrics-clojure "2.7.0"]
                  [metrics-clojure-jvm "2.7.0"]
-                 [metrics-statsd "0.1.5"]
+                 [metrics-statsd "0.1.6"]
                  [org.apache.kafka/kafka-clients "0.9.0.1"]
                  [org.clojure/clojure "1.8.0"]
                  [pjson "0.3.4"]]

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-(defproject arion "1.2.3-SNAPSHOT"
+(defproject arion "1.2.3"
   :description "Talks to Kafka so you don't have to"
   :url "https://github.com/orgsync/arion"
   :license {:name "Apache 2.0"

--- a/src/arion/kafka.clj
+++ b/src/arion/kafka.clj
@@ -87,12 +87,13 @@
                   (.metrics producer)))))
 
 (defn new-producer [brokers]
-  (Producer. (-> {:bootstrap.servers brokers
-                  :key.serializer    StringSerializer
-                  :value.serializer  ByteArraySerializer
-                  :acks              "all"
-                  :compression.type  "gzip"
-                  :retries           (int 2147483647)
-                  :linger.ms         (int 5)}
+  (Producer. (-> {:bootstrap.servers    brokers
+                  :key.serializer       StringSerializer
+                  :value.serializer     ByteArraySerializer
+                  :acks                 "all"
+                  :compression.type     "gzip"
+                  :retries              (int 2147483647)
+                  :linger.ms            (int 5)
+                  :block.on.buffer.full true}
                  stringify-keys)
              nil nil nil))

--- a/src/arion/kafka.clj
+++ b/src/arion/kafka.clj
@@ -92,6 +92,7 @@
                   :value.serializer  ByteArraySerializer
                   :acks              "all"
                   :compression.type  "gzip"
-                  :retries           (int 2147483647)}
+                  :retries           (int 2147483647)
+                  :linger.ms         (int 5)}
                  stringify-keys)
              nil nil nil))

--- a/src/arion/metrics.clj
+++ b/src/arion/metrics.clj
@@ -18,7 +18,7 @@
 
   (stop [component]
     (info "stopping statsd metrics reporter")
-    (.stop reporter)
+    (future (.stop reporter))
     (assoc component :registry nil :reporter nil))
 
   p/MetricRegistry

--- a/src/arion/queue.clj
+++ b/src/arion/queue.clj
@@ -89,6 +89,7 @@
     (let [completed (d/deferred)
           id        (uuid/v1)
           untrack   (fn [_] (swap! enqueued dissoc id))]
+      (swap! enqueued assoc id completed)
       (d/on-realized completed untrack untrack)
       (p/put! queue queue-name message id)
       completed))


### PR DESCRIPTION
Prevents unbounded growth of blocked threads waiting for puts to complete.
